### PR TITLE
Integrate mined alphas into RF backtest

### DIFF
--- a/alphagen_crypto/__init__.py
+++ b/alphagen_crypto/__init__.py
@@ -1,0 +1,17 @@
+"""Utilities for applying AlphaGen to cryptocurrency data."""
+
+from .feature_type import CryptoFeatureType
+
+__all__ = ["CryptoFeatureType", "CryptoDataCalculator", "BitcoinData"]
+
+
+def __getattr__(name: str):  # pragma: no cover - thin convenience wrapper
+    if name == "BitcoinData":
+        from .bitcoin_data import BitcoinData as _BitcoinData
+
+        return _BitcoinData
+    if name == "CryptoDataCalculator":
+        from .calculator import CryptoDataCalculator as _CryptoDataCalculator
+
+        return _CryptoDataCalculator
+    raise AttributeError(f"module 'alphagen_crypto' has no attribute {name!r}")

--- a/alphagen_crypto/alpha_mining.py
+++ b/alphagen_crypto/alpha_mining.py
@@ -1,0 +1,284 @@
+"""Tools for mining alpha expressions from Bitcoin historical data."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+import torch
+from gplearn.fitness import make_fitness
+from gplearn.functions import make_function
+from gplearn.genetic import SymbolicRegressor
+
+from alphagen.data.expression import *  # noqa: F401,F403
+from alphagen.models.linear_alpha_pool import MseAlphaPool
+from alphagen.utils.random import reseed_everything
+from alphagen_generic.operators import funcs as generic_funcs
+
+from . import BitcoinData, CryptoDataCalculator
+from .features import close, high, low, open_, target, volume, vwap  # noqa: F401
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class AlphaCandidate:
+    """Summary of an alpha expression discovered during mining."""
+
+    expression: Expression
+    expression_str: str
+    train_ic: float
+    train_ric: float
+    test_ic: float
+    test_ric: float
+
+    def to_dict(self) -> Dict[str, float]:
+        return {
+            "expression": self.expression_str,
+            "train_ic": self.train_ic,
+            "train_ric": self.train_ric,
+            "test_ic": self.test_ic,
+            "test_ric": self.test_ric,
+        }
+
+
+@dataclass
+class AlphaEnsembleSummary:
+    expressions: List[str]
+    weights: List[float]
+    train_ic: float
+    train_ric: float
+    test_ic: float
+    test_ric: float
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "expressions": self.expressions,
+            "weights": self.weights,
+            "train_ic": self.train_ic,
+            "train_ric": self.train_ric,
+            "test_ic": self.test_ic,
+            "test_ric": self.test_ric,
+        }
+
+
+@dataclass
+class AlphaMiningResult:
+    candidates: List[AlphaCandidate]
+    ensemble: AlphaEnsembleSummary
+    evaluated: int
+
+
+def _prepare_datasets(
+    dataframe: pd.DataFrame,
+    *,
+    split: str,
+    device: torch.device,
+    max_backtrack: int,
+    max_future: int,
+) -> Tuple[BitcoinData, BitcoinData]:
+    dataframe = dataframe.sort_index()
+    split_ts = pd.Timestamp(split)
+    train_df = dataframe.loc[dataframe.index <= split_ts]
+    test_df = dataframe.loc[dataframe.index > split_ts]
+
+    if len(train_df) < 200:
+        raise ValueError("Training split must contain at least 200 observations for alpha mining")
+    if len(test_df) < 30:
+        LOGGER.warning("Test split contains fewer than 30 observations; IC metrics may be noisy")
+
+    train_data = BitcoinData(
+        train_df,
+        max_backtrack_days=max_backtrack,
+        max_future_days=max_future,
+        device=device,
+    )
+    test_data = BitcoinData(
+        test_df,
+        max_backtrack_days=max_backtrack,
+        max_future_days=max_future,
+        device=device,
+    )
+    return train_data, test_data
+
+
+def _build_symbolic_regressor(
+    population_size: int,
+    generations: int,
+    seed: int,
+    function_set: Sequence,
+    verbose: bool,
+) -> SymbolicRegressor:
+    return SymbolicRegressor(
+        population_size=population_size,
+        generations=generations,
+        init_depth=(2, 5),
+        tournament_size=max(population_size // 2, 2),
+        stopping_criteria=1.0,
+        p_crossover=0.3,
+        p_subtree_mutation=0.1,
+        p_hoist_mutation=0.01,
+        p_point_mutation=0.1,
+        p_point_replace=0.6,
+        max_samples=0.9,
+        verbose=int(verbose),
+        parsimony_coefficient=0.0,
+        random_state=seed,
+        function_set=function_set,
+        const_range=None,
+        n_jobs=1,
+    )
+
+
+def _evaluate_top_candidates(
+    cache: Dict[str, float],
+    expressions: Dict[str, Expression],
+    calculator_train: CryptoDataCalculator,
+    calculator_test: CryptoDataCalculator,
+    top_n: int,
+    device: torch.device,
+) -> Tuple[List[AlphaCandidate], AlphaEnsembleSummary]:
+    ordered = sorted(cache.items(), key=lambda kv: kv[1], reverse=True)[:top_n]
+
+    candidates: List[AlphaCandidate] = []
+    expr_objects: List[Expression] = []
+    expr_strings: List[str] = []
+
+    for expr_str, _ in ordered:
+        expr = expressions[expr_str]
+        expr_objects.append(expr)
+        expr_strings.append(expr_str)
+        train_ic, train_ric = calculator_train.calc_single_all_ret(expr)
+        test_ic, test_ric = calculator_test.calc_single_all_ret(expr)
+        candidates.append(
+            AlphaCandidate(
+                expression=expr,
+                expression_str=expr_str,
+                train_ic=float(train_ic),
+                train_ric=float(train_ric),
+                test_ic=float(test_ic),
+                test_ric=float(test_ric),
+            )
+        )
+
+    pool = MseAlphaPool(
+        capacity=len(expr_objects),
+        calculator=calculator_train,
+        ic_lower_bound=None,
+        device=device,
+    )
+    pool.force_load_exprs(expr_objects)
+    train_ic, train_ric = pool.test_ensemble(calculator_train)
+    test_ic, test_ric = pool.test_ensemble(calculator_test)
+    ensemble = AlphaEnsembleSummary(
+        expressions=expr_strings,
+        weights=list(pool.weights),
+        train_ic=float(train_ic),
+        train_ric=float(train_ric),
+        test_ic=float(test_ic),
+        test_ric=float(test_ric),
+    )
+    return candidates, ensemble
+
+
+def mine_btc_alphas(
+    dataframe: pd.DataFrame,
+    *,
+    split: str,
+    population_size: int = 200,
+    generations: int = 10,
+    top_n: int = 5,
+    seed: int = 7,
+    device: torch.device = torch.device("cpu"),
+    max_backtrack: int = 120,
+    max_future: int = 60,
+    function_overrides: Optional[Iterable] = None,
+    constant_values: Optional[Sequence[float]] = None,
+    verbose: bool = False,
+) -> AlphaMiningResult:
+    """Run symbolic regression to discover Bitcoin alpha expressions."""
+
+    reseed_everything(seed)
+    train_data, test_data = _prepare_datasets(
+        dataframe,
+        split=split,
+        device=device,
+        max_backtrack=max_backtrack,
+        max_future=max_future,
+    )
+
+    calculator_train = CryptoDataCalculator(train_data, target)
+    calculator_test = CryptoDataCalculator(test_data, target)
+
+    if function_overrides is None:
+        function_set = [make_function(**func._asdict()) for func in generic_funcs]
+    else:
+        function_set = [make_function(**func._asdict()) for func in function_overrides]
+
+    if constant_values is None:
+        constant_values = (
+            -30.0,
+            -10.0,
+            -5.0,
+            -2.0,
+            -1.0,
+            -0.5,
+            -0.01,
+            0.01,
+            0.5,
+            1.0,
+            2.0,
+            5.0,
+            10.0,
+            30.0,
+        )
+
+    features = ("open_", "close", "high", "low", "volume", "vwap")
+    terminals = list(features) + [f"Constant({val})" for val in constant_values]
+
+    cache: Dict[str, float] = {}
+    expr_cache: Dict[str, Expression] = {}
+
+    def _metric(y_true, y_pred, sample_weight):  # pylint: disable=unused-argument
+        key = y_pred[0]
+        if key in cache:
+            return cache[key]
+        try:
+            expr = eval(key)
+            expr_cache[key] = expr
+            ic = calculator_train.calc_single_IC_ret(expr)
+        except Exception as exc:  # pylint: disable=broad-except
+            LOGGER.debug("Expression %s failed during evaluation: %s", key, exc)
+            ic = -1.0
+        if np.isnan(ic):
+            ic = -1.0
+        cache[key] = float(ic)
+        return cache[key]
+
+    metric = make_fitness(function=_metric, greater_is_better=True)
+    estimator = _build_symbolic_regressor(
+        population_size=population_size,
+        generations=generations,
+        seed=seed,
+        function_set=function_set,
+        verbose=verbose,
+    )
+
+    X_train = np.array([terminals])
+    y_train = np.array([[1]])
+    estimator.set_params(metric=metric)
+    estimator.fit(X_train, y_train)
+
+    candidates, ensemble = _evaluate_top_candidates(
+        cache,
+        expr_cache,
+        calculator_train,
+        calculator_test,
+        top_n,
+        device,
+    )
+
+    return AlphaMiningResult(candidates=candidates, ensemble=ensemble, evaluated=len(cache))

--- a/alphagen_crypto/bitcoin_data.py
+++ b/alphagen_crypto/bitcoin_data.py
@@ -1,0 +1,216 @@
+"""Utility dataset wrapper for Bitcoin OHLCV inputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Sequence, Union
+
+import numpy as np
+import pandas as pd
+import torch
+from torch import Tensor
+
+from .feature_type import CryptoFeatureType
+
+
+@dataclass
+class _PreloadedData:
+    tensor: Tensor
+    dates: pd.Index
+    asset_ids: pd.Index
+
+
+class BitcoinData:
+    """Container mimicking :class:`alphagen_qlib.stock_data.StockData` for Bitcoin."""
+
+    def __init__(
+        self,
+        dataframe: pd.DataFrame,
+        symbol: str = "BTC-USD",
+        *,
+        max_backtrack_days: int = 120,
+        max_future_days: int = 30,
+        features: Optional[Sequence[CryptoFeatureType]] = None,
+        device: torch.device = torch.device("cpu"),
+        preloaded: Optional[_PreloadedData] = None,
+    ) -> None:
+        if preloaded is not None:
+            self.data = preloaded.tensor
+            self._dates = preloaded.dates
+            self._asset_ids = preloaded.asset_ids
+            self.max_backtrack_days = max_backtrack_days
+            self.max_future_days = max_future_days
+            self.device = device
+            self._features = list(features) if features is not None else list(CryptoFeatureType)
+            self.symbol = symbol
+            return
+
+        if dataframe.index.tzinfo is not None or getattr(dataframe.index, "tz", None) is not None:
+            dataframe = dataframe.copy()
+            dataframe.index = dataframe.index.tz_convert(None)
+        dataframe = dataframe.sort_index()
+
+        if dataframe.index.has_duplicates:
+            dataframe = dataframe[~dataframe.index.duplicated(keep="first")]
+
+        self.symbol = symbol
+        self.max_backtrack_days = max_backtrack_days
+        self.max_future_days = max_future_days
+        self.device = device
+        self._features = list(features) if features is not None else list(CryptoFeatureType)
+
+        feature_arrays = self._build_feature_matrix(dataframe, device)
+        n_days = feature_arrays.shape[0]
+        n_features = feature_arrays.shape[1]
+
+        padded = torch.full(
+            (n_days + max_backtrack_days + max_future_days, n_features, 1),
+            float("nan"),
+            dtype=feature_arrays.dtype,
+            device=device,
+        )
+        padded[max_backtrack_days:max_backtrack_days + n_days, :, 0] = feature_arrays
+        self.data = padded
+
+        freq = self._infer_freq(dataframe.index)
+        front_index = pd.date_range(
+            end=dataframe.index[0] - freq,
+            periods=max_backtrack_days,
+            freq=freq,
+        ) if max_backtrack_days > 0 else pd.DatetimeIndex([], name=dataframe.index.name)
+        back_index = pd.date_range(
+            start=dataframe.index[-1] + freq,
+            periods=max_future_days,
+            freq=freq,
+        ) if max_future_days > 0 else pd.DatetimeIndex([], name=dataframe.index.name)
+        self._dates = front_index.append(dataframe.index).append(back_index)
+        self._asset_ids = pd.Index([symbol])
+
+    @staticmethod
+    def _infer_freq(index: pd.Index) -> pd.Timedelta:
+        if len(index) < 2:
+            return pd.Timedelta(days=1)
+        diffs = index.to_series().diff().dropna()
+        freq = diffs.median()
+        if pd.isna(freq) or freq == pd.Timedelta(0):
+            freq = pd.Timedelta(days=1)
+        return freq
+
+    def _build_feature_matrix(self, dataframe: pd.DataFrame, device: torch.device) -> Tensor:
+        frame = dataframe.copy()
+        col_map = {
+            CryptoFeatureType.OPEN: "open",
+            CryptoFeatureType.CLOSE: "close",
+            CryptoFeatureType.HIGH: "high",
+            CryptoFeatureType.LOW: "low",
+            CryptoFeatureType.VOLUME: "volume",
+            CryptoFeatureType.VWAP: "vwap",
+        }
+        normalized = frame.rename(columns=str.lower)
+        if "vwap" not in normalized.columns:
+            normalized["vwap"] = (normalized["high"] + normalized["low"] + normalized["close"]) / 3
+
+        missing = [col for col in col_map.values() if col not in normalized.columns]
+        if missing:
+            raise ValueError(f"Dataframe missing required columns: {missing}")
+
+        ordered_columns = [col_map[feature] for feature in self._features]
+        # ``DataFrame.to_numpy`` keeps a consistent shape even when duplicate
+        # columns are requested, whereas stacking individual ``Series`` can
+        # produce ragged shapes if pandas returns a 2-D array for any column.
+        values = normalized.loc[:, ordered_columns].to_numpy(dtype=np.float32)
+        return torch.tensor(values, dtype=torch.float32, device=device)
+
+    def __getitem__(self, slc: Union[slice, str]) -> "BitcoinData":
+        if isinstance(slc, str):
+            return self[self.find_date_slice(slc)]
+        if slc.step is not None:
+            raise ValueError("Only support slice with step=None")
+        start = 0 if slc.start is None else slc.start
+        stop = self.n_days if slc.stop is None else slc.stop
+        start = max(0, start)
+        stop = min(self.n_days, stop)
+        total_start = start
+        total_stop = stop + self.max_backtrack_days + self.max_future_days
+        total_stop = min(total_stop, self.data.shape[0])
+        idx_range = slice(total_start, total_stop)
+        data = self.data[idx_range]
+        return BitcoinData(
+            dataframe=pd.DataFrame(),
+            symbol=self.symbol,
+            max_backtrack_days=self.max_backtrack_days,
+            max_future_days=self.max_future_days,
+            features=self._features,
+            device=self.device,
+            preloaded=_PreloadedData(
+                tensor=data,
+                dates=self._dates[idx_range],
+                asset_ids=self._asset_ids,
+            ),
+        )
+
+    def find_date_index(self, date: str, exclusive: bool = False) -> int:
+        ts = pd.Timestamp(date)
+        idx = self._dates.searchsorted(ts)
+        if exclusive and idx < len(self._dates) and self._dates[idx] == ts:
+            idx += 1
+        idx -= self.max_backtrack_days
+        if idx < 0 or idx > self.n_days:
+            raise ValueError(
+                f"Date {date} is out of range: available "
+                f"[{self._dates[self.max_backtrack_days]}, {self._dates[self.max_backtrack_days + self.n_days - 1]}]"
+            )
+        return idx
+
+    def find_date_slice(self, start_time: Optional[str] = None, end_time: Optional[str] = None) -> slice:
+        start = None if start_time is None else self.find_date_index(start_time)
+        stop = None if end_time is None else self.find_date_index(end_time, exclusive=False)
+        return slice(start, stop)
+
+    @property
+    def n_features(self) -> int:
+        return len(self._features)
+
+    @property
+    def n_stocks(self) -> int:
+        return 1
+
+    @property
+    def n_days(self) -> int:
+        return self.data.shape[0] - self.max_backtrack_days - self.max_future_days
+
+    @property
+    def stock_ids(self) -> pd.Index:
+        return self._asset_ids
+
+    def make_dataframe(
+        self,
+        data: Union[Tensor, List[Tensor]],
+        columns: Optional[List[str]] = None,
+    ) -> pd.DataFrame:
+        if isinstance(data, list):
+            data = torch.stack(data, dim=2)
+        if len(data.shape) == 2:
+            data = data.unsqueeze(2)
+        if columns is None:
+            columns = [str(i) for i in range(data.shape[2])]
+        n_days, n_stocks, n_columns = data.shape
+        if self.n_days != n_days:
+            raise ValueError(
+                f"number of days in tensor ({n_days}) doesn't match current data ({self.n_days})"
+            )
+        if self.n_stocks != n_stocks:
+            raise ValueError(
+                f"number of assets in tensor ({n_stocks}) doesn't match current data ({self.n_stocks})"
+            )
+        if len(columns) != n_columns:
+            raise ValueError(
+                f"size of columns ({len(columns)}) doesn't match tensor feature count ({n_columns})"
+            )
+        if self.max_future_days == 0:
+            date_index = self._dates[self.max_backtrack_days:]
+        else:
+            date_index = self._dates[self.max_backtrack_days:-self.max_future_days]
+        index = pd.MultiIndex.from_product([date_index, self._asset_ids])
+        reshaped = data.reshape(-1, n_columns)
+        return pd.DataFrame(reshaped.detach().cpu().numpy(), index=index, columns=columns)

--- a/alphagen_crypto/calculator.py
+++ b/alphagen_crypto/calculator.py
@@ -1,0 +1,26 @@
+"""Tensor-based alpha calculator for cryptocurrency data."""
+
+from typing import Optional
+
+from torch import Tensor
+
+from alphagen.data.calculator import TensorAlphaCalculator
+from alphagen.data.expression import Expression
+from alphagen.utils.pytorch_utils import normalize_by_day
+
+from .bitcoin_data import BitcoinData
+
+
+class CryptoDataCalculator(TensorAlphaCalculator):
+    """Alpha calculator that works with :class:`BitcoinData`."""
+
+    def __init__(self, data: BitcoinData, target: Optional[Expression] = None) -> None:
+        super().__init__(normalize_by_day(target.evaluate(data)) if target is not None else None)
+        self.data = data
+
+    def evaluate_alpha(self, expr: Expression) -> Tensor:
+        return normalize_by_day(expr.evaluate(self.data))
+
+    @property
+    def n_days(self) -> int:
+        return self.data.n_days

--- a/alphagen_crypto/data_fetching.py
+++ b/alphagen_crypto/data_fetching.py
@@ -1,0 +1,73 @@
+"""Utilities for retrieving cryptocurrency market data."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pandas as pd
+import yfinance as yf
+
+
+def fetch_btc_ohlcv(start: Optional[str] = None, end: Optional[str] = None) -> pd.DataFrame:
+    """Fetch daily Bitcoin OHLCV data from Yahoo Finance.
+
+    Parameters
+    ----------
+    start:
+        Optional start date (inclusive) in ``YYYY-MM-DD`` format.  If ``None`` the
+        earliest available observation from Yahoo Finance is used.
+    end:
+        Optional end date (inclusive) in ``YYYY-MM-DD`` format.  If ``None`` the
+        latest available observation is used.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A dataframe indexed by ``DatetimeIndex`` containing the OHLCV columns.
+
+    Raises
+    ------
+    RuntimeError
+        If Yahoo Finance does not return any data for ``BTC-USD``.
+    """
+
+    start_ts = pd.Timestamp(start) if start is not None else None
+    end_ts = pd.Timestamp(end) if end is not None else pd.Timestamp.today()
+
+    # yfinance treats ``end`` as exclusive; request the following day so the
+    # supplied end date is included in the data that is returned.
+    download_end: Optional[str]
+    if end_ts is not None:
+        download_end = (end_ts + pd.Timedelta(days=1)).strftime("%Y-%m-%d")
+    else:
+        download_end = None
+
+    data = yf.download(
+        "BTC-USD",
+        start=None if start_ts is None else start_ts.strftime("%Y-%m-%d"),
+        end=download_end,
+        progress=False,
+        auto_adjust=False,
+        interval="1d",
+    )
+
+    if data.empty:
+        raise RuntimeError("No data returned from Yahoo Finance for BTC-USD")
+
+    if isinstance(data.columns, pd.MultiIndex):
+        data.columns = [str(col).title() for col, *_ in data.columns]
+    else:
+        data = data.rename(columns=str.title)
+
+    if "Adj Close" in data.columns:
+        data = data.drop(columns=["Adj Close"])
+
+    data.index = data.index.tz_localize(None)
+    data = data.sort_index()
+
+    if start_ts is not None:
+        data = data.loc[data.index >= start_ts]
+    if end_ts is not None:
+        data = data.loc[data.index <= end_ts]
+
+    return data

--- a/alphagen_crypto/feature_type.py
+++ b/alphagen_crypto/feature_type.py
@@ -1,0 +1,12 @@
+from enum import IntEnum
+
+
+class CryptoFeatureType(IntEnum):
+    """Feature ordering for cryptocurrency OHLCV data."""
+
+    OPEN = 0
+    CLOSE = 1
+    HIGH = 2
+    LOW = 3
+    VOLUME = 4
+    VWAP = 5

--- a/alphagen_crypto/features.py
+++ b/alphagen_crypto/features.py
@@ -1,0 +1,16 @@
+"""Feature shortcuts for cryptocurrency alpha generation."""
+
+from alphagen.data.expression import Feature, Ref
+
+from .feature_type import CryptoFeatureType
+
+
+high = High = HIGH = Feature(CryptoFeatureType.HIGH)
+low = Low = LOW = Feature(CryptoFeatureType.LOW)
+volume = Volume = VOLUME = Feature(CryptoFeatureType.VOLUME)
+open_ = Open = OPEN = Feature(CryptoFeatureType.OPEN)
+close = Close = CLOSE = Feature(CryptoFeatureType.CLOSE)
+vwap = Vwap = VWAP = Feature(CryptoFeatureType.VWAP)
+
+# Default target: 20-day forward return.
+target = Ref(close, -20) / close - 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,7 @@ shimmy==1.1.0
 fire
 openai==1.2.3
 num2words
+requests
+yfinance
+scikit-learn
+scipy

--- a/scripts/btc_alpha_generator.py
+++ b/scripts/btc_alpha_generator.py
@@ -1,0 +1,103 @@
+"""Automatic formulaic alpha generation using Bitcoin data only."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Dict, Optional, Sequence
+
+import pandas as pd
+import torch
+
+from alphagen.utils.random import reseed_everything
+
+from alphagen_crypto.alpha_mining import AlphaMiningResult, mine_btc_alphas
+from alphagen_crypto.data_fetching import fetch_btc_ohlcv
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _setup_logging(verbose: bool) -> None:
+    level = logging.INFO if verbose else logging.WARNING
+    logging.basicConfig(level=level, format="[%(levelname)s] %(message)s")
+
+
+def _load_csv(path: Path) -> pd.DataFrame:
+    LOGGER.info("Loading BTC data from %s", path)
+    df = pd.read_csv(path, parse_dates=[0])
+    df = df.set_index(df.columns[0])
+    required = {"Open", "High", "Low", "Close", "Volume"}
+    missing = required.difference(df.columns)
+    if missing:
+        raise ValueError(f"CSV file missing required columns: {sorted(missing)}")
+    return df.sort_index()
+
+
+def generate_alphas(args) -> Dict[str, object]:
+    reseed_everything(args.seed)
+    device = torch.device(args.device)
+
+    if args.csv_path:
+        dataframe = _load_csv(Path(args.csv_path))
+    else:
+        dataframe = fetch_btc_ohlcv(args.start, args.end)
+
+    mining_result: AlphaMiningResult = mine_btc_alphas(
+        dataframe,
+        split=args.split,
+        population_size=args.population_size,
+        generations=args.generations,
+        top_n=args.top_n,
+        seed=args.seed,
+        device=device,
+        max_backtrack=args.max_backtrack,
+        max_future=args.max_future,
+        verbose=args.verbose,
+    )
+
+    settings = vars(args).copy()
+    return {
+        "settings": settings,
+        "n_evaluated": mining_result.evaluated,
+        "alphas": [candidate.to_dict() for candidate in mining_result.candidates],
+        "ensemble": mining_result.ensemble.to_dict(),
+    }
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--start", default="2010-07-17", help="Start date for the dataset (inclusive)")
+    parser.add_argument("--end", default=pd.Timestamp.today().strftime("%Y-%m-%d"), help="End date for the dataset")
+    parser.add_argument("--split", default="2020-01-01", help="Split date between train/test")
+    parser.add_argument("--population-size", type=int, default=500, help="Population size for GP")
+    parser.add_argument("--generations", type=int, default=30, help="Number of GP generations")
+    parser.add_argument("--top-n", type=int, default=10, help="Number of top alphas to report")
+    parser.add_argument("--seed", type=int, default=7, help="Random seed")
+    parser.add_argument("--device", default="cpu", help="Torch device to use")
+    parser.add_argument("--csv-path", help="Optional CSV file with Bitcoin OHLCV data")
+    parser.add_argument("--max-backtrack", type=int, default=120, help="Maximum historical lookback in days")
+    parser.add_argument("--max-future", type=int, default=60, help="Future horizon in days for targets")
+    parser.add_argument("--output", help="Optional path to save results as JSON")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    args = parse_args(argv)
+    _setup_logging(args.verbose)
+    results = generate_alphas(args)
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as f:
+            json.dump(results, f, indent=2)
+        LOGGER.info("Saved results to %s", output_path)
+    else:
+        print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/scripts/btc_rf_backtest.py
+++ b/scripts/btc_rf_backtest.py
@@ -1,0 +1,321 @@
+"""Backtest a Random Forest Bitcoin strategy with leverage optimization."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from scipy import optimize
+from sklearn.ensemble import RandomForestRegressor
+import torch
+
+from alphagen_crypto import BitcoinData, CryptoDataCalculator
+from alphagen_crypto.alpha_mining import AlphaCandidate, AlphaMiningResult, mine_btc_alphas
+from alphagen_crypto.data_fetching import fetch_btc_ohlcv
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class BacktestResult:
+    equity_curve: pd.Series
+    buy_and_hold: pd.Series
+    leverage: pd.Series
+    predictions: pd.Series
+    realized_returns: pd.Series
+    mined_alphas: Optional[List[str]] = None
+
+    @property
+    def final_return(self) -> float:
+        return float(self.equity_curve.iloc[-1] - 1.0)
+
+    @property
+    def buy_and_hold_return(self) -> float:
+        return float(self.buy_and_hold.iloc[-1] - 1.0)
+
+    @property
+    def annualized_sharpe(self) -> float:
+        daily_returns = self.equity_curve.pct_change().dropna()
+        if daily_returns.empty:
+            return float("nan")
+        return np.sqrt(252) * daily_returns.mean() / daily_returns.std(ddof=0)
+
+
+def _setup_logging(verbose: bool) -> None:
+    level = logging.INFO if verbose else logging.WARNING
+    logging.basicConfig(level=level, format="[%(levelname)s] %(message)s")
+
+
+def _build_feature_table(df: pd.DataFrame, lookback: int) -> pd.DataFrame:
+    frame = df.copy()
+    frame = frame.rename(columns=str.lower)
+    frame["return"] = frame["close"].pct_change()
+    frame["log_return"] = np.log(frame["close"]).diff()
+    frame["volume_change"] = frame["volume"].pct_change()
+    frame["high_low_spread"] = (frame["high"] - frame["low"]) / frame["close"]
+    frame["vwap"] = (frame["high"] + frame["low"] + frame["close"]) / 3
+
+    for window in (3, 7, 14, 30):
+        ma_series = frame["close"].rolling(window).mean()
+        frame[f"ma_{window}"] = ma_series
+
+        ratio = frame["close"] / frame[f"ma_{window}"]
+        if isinstance(ratio, pd.DataFrame):
+            ratio = ratio.iloc[:, 0]
+        frame[f"ma_ratio_{window}"] = ratio
+
+        frame[f"volatility_{window}"] = frame["return"].rolling(window).std()
+
+    for lag in range(1, lookback + 1):
+        frame[f"return_lag_{lag}"] = frame["return"].shift(lag)
+        frame[f"volume_lag_{lag}"] = frame["volume_change"].shift(lag)
+        frame[f"spread_lag_{lag}"] = frame["high_low_spread"].shift(lag)
+
+    frame["target"] = frame["return"].shift(-1)
+
+    frame = frame.dropna()
+    return frame
+
+
+def _compute_alpha_feature_frame(
+    dataframe: pd.DataFrame,
+    candidates: Sequence[AlphaCandidate],
+    *,
+    device: torch.device,
+    max_backtrack: int,
+    max_future: int,
+) -> pd.DataFrame:
+    dataset = BitcoinData(
+        dataframe,
+        max_backtrack_days=max_backtrack,
+        max_future_days=max_future,
+        device=device,
+    )
+    calculator = CryptoDataCalculator(dataset)
+    frames: List[pd.DataFrame] = []
+    for idx, candidate in enumerate(candidates, start=1):
+        tensor = calculator.evaluate_alpha(candidate.expression)
+        df = dataset.make_dataframe(tensor, columns=[f"alpha_{idx}"])
+        df = df.xs(dataset.symbol, level=1)
+        frames.append(df.rename(columns={f"alpha_{idx}": f"alpha_{idx}"}))
+    if not frames:
+        return pd.DataFrame(index=dataframe.index)
+    combined = pd.concat(frames, axis=1)
+    combined.index = pd.DatetimeIndex(combined.index)
+    combined = combined.sort_index()
+    return combined
+
+
+def _augment_with_mined_alphas(
+    dataframe: pd.DataFrame,
+    feature_table: pd.DataFrame,
+    args: argparse.Namespace,
+) -> Tuple[pd.DataFrame, Optional[AlphaMiningResult]]:
+    if args.alpha_top_n <= 0:
+        return feature_table, None
+
+    device = torch.device(args.alpha_device)
+    mining_result = mine_btc_alphas(
+        dataframe,
+        split=args.split,
+        population_size=args.alpha_population_size,
+        generations=args.alpha_generations,
+        top_n=args.alpha_top_n,
+        seed=args.seed,
+        device=device,
+        max_backtrack=args.alpha_max_backtrack,
+        max_future=args.alpha_max_future,
+        verbose=args.verbose,
+    )
+
+    if not mining_result.candidates:
+        LOGGER.warning("Alpha mining returned no candidates; continuing without additional features")
+        return feature_table, mining_result
+
+    LOGGER.info(
+        "Incorporating %d mined alphas into the feature matrix", len(mining_result.candidates)
+    )
+    for idx, candidate in enumerate(mining_result.candidates, start=1):
+        LOGGER.info(
+            "Alpha %d: %s (train IC %.3f, test IC %.3f)",
+            idx,
+            candidate.expression_str,
+            candidate.train_ic,
+            candidate.test_ic,
+        )
+
+    alpha_frame = _compute_alpha_feature_frame(
+        dataframe,
+        mining_result.candidates,
+        device=device,
+        max_backtrack=args.alpha_max_backtrack,
+        max_future=args.alpha_max_future,
+    )
+    feature_table = feature_table.join(alpha_frame, how="inner")
+    feature_table = feature_table.dropna()
+    return feature_table, mining_result
+
+
+def _fit_random_forest(X_train: pd.DataFrame, y_train: pd.Series, args: argparse.Namespace) -> RandomForestRegressor:
+    model = RandomForestRegressor(
+        n_estimators=args.n_estimators,
+        max_depth=args.max_depth,
+        min_samples_leaf=args.min_samples_leaf,
+        random_state=args.seed,
+        n_jobs=-1,
+    )
+    model.fit(X_train, y_train)
+    return model
+
+
+def _optimize_leverage(pred_return: float, sigma: float, args: argparse.Namespace) -> float:
+    sigma2 = max(sigma ** 2, 1e-8)
+
+    def objective(weight: float) -> float:
+        # Maximize mean-variance utility with SciPy (minimize negative utility).
+        utility = weight * pred_return - 0.5 * args.risk_aversion * sigma2 * weight ** 2
+        return -utility
+
+    result = optimize.minimize_scalar(
+        objective,
+        bounds=(-args.max_leverage, args.max_leverage),
+        method="bounded",
+        options={"xatol": 1e-3},
+    )
+    if not result.success:
+        LOGGER.debug("Leverage optimization failed: %s", result.message)
+    return float(np.clip(result.x, -args.max_leverage, args.max_leverage))
+
+
+def run_backtest(args: argparse.Namespace) -> BacktestResult:
+    LOGGER.info("Fetching Bitcoin data from Yahoo Finance")
+    data = fetch_btc_ohlcv(args.start, args.end)
+
+    feature_table = _build_feature_table(data, args.lookback)
+
+    mining_result: Optional[AlphaMiningResult] = None
+    if not args.disable_alpha_mining:
+        feature_table, mining_result = _augment_with_mined_alphas(data, feature_table, args)
+
+    split_ts = pd.Timestamp(args.split)
+    train_mask = feature_table.index <= split_ts
+    test_mask = feature_table.index > split_ts
+
+    train_count = int(train_mask.sum())
+    test_count = int(test_mask.sum())
+
+    if train_count < args.min_train_size:
+        required_idx = args.min_train_size - 1
+        if required_idx >= len(feature_table):
+            raise ValueError(
+                "Dataset does not contain enough rows to satisfy the minimum"
+                f" training size of {args.min_train_size}."
+            )
+        adjusted_split = feature_table.index[required_idx]
+        LOGGER.warning(
+            "Requested split %s yields only %d training rows; adjusting split to %s",
+            split_ts.date(),
+            train_count,
+            adjusted_split.date(),
+        )
+        train_mask = feature_table.index <= adjusted_split
+        test_mask = feature_table.index > adjusted_split
+        train_count = int(train_mask.sum())
+        test_count = int(test_mask.sum())
+
+    if test_count < args.min_test_size:
+        raise ValueError(
+            "Test data must contain at least"
+            f" {args.min_test_size} observations after the split"
+        )
+
+    train = feature_table.loc[train_mask]
+    test = feature_table.loc[test_mask]
+
+    X_train = train.drop(columns=["target"])
+    y_train = train["target"]
+    X_test = test.drop(columns=["target"])
+    y_test = test["target"]
+
+    model = _fit_random_forest(X_train, y_train, args)
+    predictions = pd.Series(model.predict(X_test), index=X_test.index, name="prediction")
+
+    sigma = float(y_train.std(ddof=0))
+    leverages = predictions.apply(lambda r: _optimize_leverage(float(r), sigma, args))
+
+    strategy_returns = leverages * y_test
+    equity_curve = (1 + strategy_returns).cumprod()
+    buy_and_hold = (1 + y_test).cumprod()
+
+    return BacktestResult(
+        equity_curve=equity_curve,
+        buy_and_hold=buy_and_hold,
+        leverage=leverages,
+        predictions=predictions,
+        realized_returns=y_test,
+        mined_alphas=[candidate.expression_str for candidate in mining_result.candidates]
+        if mining_result
+        else None,
+    )
+
+
+def _plot_results(result: BacktestResult, output_path: Path) -> None:
+    fig, ax = plt.subplots(figsize=(10, 6))
+    result.equity_curve.plot(ax=ax, label="RF Strategy")
+    result.buy_and_hold.plot(ax=ax, label="Buy and Hold")
+    ax.set_title("Random Forest Bitcoin Strategy vs Buy and Hold")
+    ax.set_ylabel("Cumulative Return (Growth of $1)")
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path)
+    plt.close(fig)
+    LOGGER.info("Saved performance plot to %s", output_path)
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--start", default="2010-07-17", help="Start date for the dataset (inclusive)")
+    parser.add_argument("--end", default=pd.Timestamp.today().strftime("%Y-%m-%d"), help="End date for the dataset (inclusive)")
+    parser.add_argument("--split", default="2019-12-31", help="Train/test split date")
+    parser.add_argument("--lookback", type=int, default=10, help="Number of lagged days to include in features")
+    parser.add_argument("--n-estimators", type=int, default=300, help="Random forest trees")
+    parser.add_argument("--max-depth", type=int, default=8, help="Maximum tree depth")
+    parser.add_argument("--min-samples-leaf", type=int, default=3, help="Minimum samples per leaf")
+    parser.add_argument("--risk-aversion", type=float, default=5.0, help="Risk aversion parameter for leverage optimization")
+    parser.add_argument("--max-leverage", type=float, default=3.0, help="Maximum absolute leverage allowed")
+    parser.add_argument("--plot-path", type=Path, default=Path("images/btc_rf_strategy.png"), help="Where to save the performance comparison plot")
+    parser.add_argument("--seed", type=int, default=7, help="Random seed for the random forest")
+    parser.add_argument("--min-train-size", type=int, default=200, help="Minimum number of rows required in the training window")
+    parser.add_argument("--min-test-size", type=int, default=30, help="Minimum number of rows required in the testing window")
+    parser.add_argument("--disable-alpha-mining", action="store_true", help="Skip mining formulaic alphas before training the model")
+    parser.add_argument("--alpha-population-size", type=int, default=200, help="Population size for the symbolic regression alpha search")
+    parser.add_argument("--alpha-generations", type=int, default=12, help="Number of generations for the symbolic regression alpha search")
+    parser.add_argument("--alpha-top-n", type=int, default=5, help="Number of mined alphas to append as features")
+    parser.add_argument("--alpha-max-backtrack", type=int, default=120, help="Maximum historical lookback used when mining alphas")
+    parser.add_argument("--alpha-max-future", type=int, default=60, help="Future horizon used when mining alphas")
+    parser.add_argument("--alpha-device", default="cpu", help="Torch device to use during alpha mining")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    args = parse_args(argv)
+    _setup_logging(args.verbose)
+    result = run_backtest(args)
+    _plot_results(result, args.plot_path)
+
+    LOGGER.info("Final cumulative return (strategy): %.2f%%", result.final_return * 100)
+    LOGGER.info("Final cumulative return (buy & hold): %.2f%%", result.buy_and_hold_return * 100)
+    LOGGER.info("Annualized Sharpe ratio (strategy): %.2f", result.annualized_sharpe)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- add a reusable alpha mining helper that discovers top GP expressions and ensemble weights for BTC data
- refactor the BTC alpha generator CLI to consume the shared mining helper
- feed the mined alpha factors into the RF backtest with configurable mining parameters

## Testing
- python -m scripts.btc_rf_backtest --max-leverage 10 --verbose --alpha-population-size 20 --alpha-generations 2 --alpha-top-n 2 *(fails: ModuleNotFoundError: No module named 'matplotlib')*
- python -m scripts.btc_alpha_generator --help *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68d60d4104488321b466ba900e625fbb